### PR TITLE
Add a CI Workflow

### DIFF
--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -29,3 +29,11 @@ jobs:
     - run: npm run build
     - run: npm run test:unit
     - run: npm run test:e2e
+    - name: Upload Cypress evidence
+      uses: actions/upload-artifact@v3
+      with:
+        name: cypress-evidence
+        path: |
+          cypress/screenshots
+          cypress/videos
+        if-no-files-found: ignore

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build and lint the source code and run tests across different versions of node.
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run build
+    - run: npm run test:unit
+    - run: npm run test:e2e


### PR DESCRIPTION
Adds a [Gihub Actions](https://github.com/features/actions) workflow definition file that does the following (once for each currently-supported Node.js version):

1. Checks out the repository
2. Sets up Node
3. Runs `npm ci`
4. Runs `npm run lint` (to lint the code)
5. Runs `npm run build` (type-checks and then builds the Vue app)
6. Runs `npm run test:unit` (unit tests)
7. Runs `npm run test:e2e` ([Cypress](https://www.cypress.io/) E2E tests)