### PR TITLE
Stop Dependabot Auto-Rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Updated the Dependabot `rebase-strategy` (see [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy)) to `disabled` to stop it auto-rebasing changes, because it force-pushes and this doesn't seem to trigger the `CodeQL` check that's required to merge PRs.