### PR TITLE
Add a Deployment Pipeline

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -40,7 +40,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az storage blob upload-batch --account-name ${{ vars.MILFORD_MENU_STORAGE_ACCOUNT_NAME }} --auth-mode key -d '$web' -s dist
+            az storage blob upload-batch --account-name ${{ vars.MILFORD_MENU_STORAGE_ACCOUNT_NAME }} --auth-mode key -d '$web' -s dist --overwrite true
       - name: Logout of Azure
         run: |
           az logout

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -1,29 +1,44 @@
+# This workflow will build the source code, authenticate with Azure and then upload the built application to a storage account
+
 name: Deploy Static Site
 
 on:
-  push:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["Node.js CI"]
+    types: [completed]
+    branches: [main]
 
 jobs:
-  build:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 
-    environment: 
+    environment:
       name: Production
       url: https://milfordmenu.z35.web.core.windows.net/
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: azure/login@v1
-      with:
-        creds: ${{ secrets.MILFORD_MENU_SERVICE_PRINCIPLE }}
-    - name: Upload to blob storage
-      uses: azure/CLI@v1
-      with:
-        inlineScript: |
-          az storage blob upload-batch --account-name ${{ vars.MILFORD_MENU_STORAGE_ACCOUNT_NAME }} --auth-mode key -d '$web' -s .
-    - name: Logout of Azure
-      run: |
-        az logout
-      if: always()
+      - uses: actions/checkout@v3
+
+      # Build the application
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build-only
+
+      # Upload to Azure
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.MILFORD_MENU_SERVICE_PRINCIPLE }}
+      - name: Upload to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload-batch --account-name ${{ vars.MILFORD_MENU_STORAGE_ACCOUNT_NAME }} --auth-mode key -d '$web' -s dist
+      - name: Logout of Azure
+        run: |
+          az logout
+        if: always()

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -8,6 +8,9 @@ on:
     types: [completed]
     branches: [main]
 
+  # TODO: Remove this!
+  push:
+
 jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -8,12 +8,9 @@ on:
     types: [completed]
     branches: [main]
 
-  # TODO: Remove this!
-  push:
-
 jobs:
   deploy:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["Node.js CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, add-deployment-pipeline]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["Node.js CI"]
     types: [completed]
-    branches: [main, add-deployment-pipeline]
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -1,0 +1,29 @@
+name: Deploy Static Site
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    environment: 
+      name: Production
+      url: https://milfordmenu.z35.web.core.windows.net/
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: azure/login@v1
+      with:
+        creds: ${{ secrets.MILFORD_MENU_SERVICE_PRINCIPLE }}
+    - name: Upload to blob storage
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az storage blob upload-batch --account-name ${{ vars.MILFORD_MENU_STORAGE_ACCOUNT_NAME }} --auth-mode key -d '$web' -s .
+    - name: Logout of Azure
+      run: |
+        az logout
+      if: always()

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -4,13 +4,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -18,22 +17,22 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run lint
-    - run: npm run build
-    - run: npm run test:unit
-    - run: npm run test:e2e
-    - name: Upload Cypress evidence
-      uses: actions/upload-artifact@v3
-      with:
-        name: cypress-evidence
-        path: |
-          cypress/screenshots
-          cypress/videos
-        if-no-files-found: ignore
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm run test:unit
+      - run: npm run test:e2e
+      - name: Upload Cypress evidence
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-evidence
+          path: |
+            cypress/screenshots
+            cypress/videos
+          if-no-files-found: ignore


### PR DESCRIPTION
This PR adds a workflow that will build the application and deploy it to an Azure storage blob in a storage account specified by the `MILFORD_MENU_STORAGE_ACCOUNT_NAME` environment variable. A `MILFORD_MENU_SERVICE_PRINCIPLE` secret is required to allow authentication with Azure. This approach is based on [Azure Storage documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-static-site-github-actions?tabs=userlevel).

The workflow will only run on completion of the `Node.js CI` workflow when it runs on the `main` branch and the `deploy` job will only run if the CI workflow completed successfully.

The `Production` environment is used to obtain environment variables/secrets.