### PR TITLE
Only Install Husky if not Running in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # milford-menu
 
-This template should help get you started developing with Vue 3 in Vite.
+A simple Vue app to show a school menu.
 
 ## Recommended IDE Setup
 
@@ -66,3 +66,16 @@ npm run test:e2e
 ```sh
 npm run lint
 ```
+
+### Git Hooks
+[Husky](https://typicode.github.io/husky) is used to enable git hooks for this repository. They will be automatically enabled when running `npm install`.
+
+These hooks perform certain recommended validations (linting, running the unit tests, etc.) before commit, and will block a commit if one of these validations fails. See the files in the [.husky](.husky) directory for the full list of commands executed.
+
+#### Bypassing Hooks
+If you need to bypass the git hooks for some reason (please make sure you at least understand why!), you can use the `--no-verify` argument to certain Git commands. E.g.:
+```bash
+git commit -m "This commit is unverified!" --no-verify
+```
+
+See the [Husky documentation](https://typicode.github.io/husky/#/?id=bypass-hooks) for full details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-vue": "^9.3.0",
         "husky": "^8.0.3",
+        "is-ci": "^3.0.1",
         "jsdom": "^21.1.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
-    "prepare": "husky install"
+    "prepare": "is-ci || husky install"
   },
   "dependencies": {
     "vue": "^3.2.47"
@@ -31,6 +31,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-vue": "^9.3.0",
     "husky": "^8.0.3",
+    "is-ci": "^3.0.1",
     "jsdom": "^21.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",


### PR DESCRIPTION
Uses [is-ci](https://www.npmjs.com/package/is-ci) to avoid installing Husky (and so running the Git pre-commit hooks) when `npm install` is run on a CI server. Follows the [approach documented in the Husky docs](https://typicode.github.io/husky/#/?id=with-is-ci).

This prevents us unnecessarily installing Husky, and potentially re-running linting, unit tests, etc. as part of our builds if they ever make a commit, or the hooks are updated to run for other operations.