### PR TITLE
Re-enable Dependabot Rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    rebase-strategy: "disabled"


### PR DESCRIPTION
Re-enable automatic rebasing of Dependabot PRs. See the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy).