### PR TITLE
Update CI Pipeline Node Versions

### DIFF
--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Update the CI pipeline to remove Node 14 (it's no longer supported) and add Node 19 & 20. So the app's building against the currently-supported versions of Node.