### PR TITLE
Update Actions Versions

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -19,12 +19,12 @@ jobs:
       url: https://milfordmenu.z35.web.core.windows.net/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Build the application
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: "npm"
       - run: npm ci
       - run: npm run build-only

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [18.x, 20.x, 21.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -29,7 +29,7 @@ jobs:
       - run: npm run test:unit
       - run: npm run test:e2e
       - name: Upload Cypress evidence
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-evidence-node-${{ matrix.node-version }}
           path: |

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm run test:unit
       - run: npm run test:e2e
       - name: Upload Cypress evidence
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-evidence-node-${{ matrix.node-version }}
           path: |

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm run test:unit
       - run: npm run test:e2e
       - name: Upload Cypress evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-evidence-node-${{ matrix.node-version }}
           path: |


### PR DESCRIPTION
Updates the versions of Github Actions used where possible, to move to versions that support Node 20 (and remove the deprecation warning seen in the Actions UI).