### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sonikblue/milford-menu/security/code-scanning/1](https://github.com/sonikblue/milford-menu/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/node.js-ci.yml` at the workflow root (preferred here since there is one job and all steps share the same minimal need).  
Use:

- `contents: read`

This is the minimal safe baseline for checkout/build/test workflows and aligns with the CodeQL suggestion. No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
